### PR TITLE
Windows: Add guard for snprintf.

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -29,6 +29,36 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+
+#include <stdarg.h>
+#define snprintf c99_snprintf
+
+inline int c99_vsnprintf(char* str, size_t size, const char* format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(str, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+inline int c99_snprintf(char* str, size_t size, const char* format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(str, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+#endif // _MSC_VER
+
 #define out_of_memory() do {                    \
     fprintf(stderr, "Out of memory.\n");    \
     exit(EXIT_FAILURE);                     \
@@ -1172,9 +1202,9 @@ void emit_string(SB *out, const char *str)
             strcpy(b, "\\uFFFD");
             b += 6;
           } else {
-            *b++ = 0xEF;
-            *b++ = 0xBF;
-            *b++ = 0xBD;
+            *b++ = 0xEFu;
+            *b++ = 0xBFu;
+            *b++ = 0xBDu;
           }
           s++;
         } else if (c < 0x1F || (c >= 0x80 && escape_unicode)) {


### PR DESCRIPTION
Also fixes the warning for unsigned char*.
