### PR TITLE
Add missing headers to install-headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,10 +271,17 @@ $(DESTDIR)$(PREFIX)/include/%.h: include/%.h \
 
 install-headers: $(DESTDIR)$(PREFIX)/include/sass.h \
                  $(DESTDIR)$(PREFIX)/include/sass/base.h \
-                 $(DESTDIR)$(PREFIX)/include/sass/version.h \
-                 $(DESTDIR)$(PREFIX)/include/sass/values.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/compiler.h \
                  $(DESTDIR)$(PREFIX)/include/sass/context.h \
-                 $(DESTDIR)$(PREFIX)/include/sass/functions.h
+                 $(DESTDIR)$(PREFIX)/include/sass/enums.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/error.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/functions.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/fwdecl.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/import.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/lists.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/traces.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/values.h \
+                 $(DESTDIR)$(PREFIX)/include/sass/version.h
 
 $(DESTDIR)$(PREFIX)/lib/%.a: lib/%.a \
                              | $(DESTDIR)$(PREFIX)/lib

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -7,12 +7,17 @@
 INCFILES = \
 	sass.h \
 	sass/base.h \
-	sass/fwdecl.h \
-	sass/enums.h \
-	sass/values.h \
-	sass/version.h \
+	sass/compiler.h \
 	sass/context.h \
-	sass/function.h
+	sass/enums.h \
+	sass/error.h \
+	sass/function.h \
+	sass/fwdecl.h \
+	sass/import.h \
+	sass/lists.h \
+	sass/traces.h \
+	sass/values.h \
+	sass/version.h
 
 HPPFILES = \
 	ast.hpp \


### PR DESCRIPTION
I'm not familiar with the correct autotools invocation, it looks like these are already in `Makefile.conf` but not included? either way I needed these to start building against a prefix