### PR TITLE
make sass_make_map error on unknown arguments

### DIFF
--- a/include/sass/values.h
+++ b/include/sass/values.h
@@ -67,7 +67,7 @@ ADDAPI struct SassValue* ADDCALL sass_make_number2(double val, const char* unit)
 
 ADDAPI struct SassValue* ADDCALL sass_make_color   (double r, double g, double b, double a);
 ADDAPI struct SassValue* ADDCALL sass_make_list    (enum SassSeparator sep, bool is_bracketed);
-ADDAPI struct SassValue* ADDCALL sass_make_map     ();
+ADDAPI struct SassValue* ADDCALL sass_make_map     (void);
 ADDAPI struct SassValue* ADDCALL sass_make_error   (const char* msg);
 ADDAPI struct SassValue* ADDCALL sass_make_warning (const char* msg);
 

--- a/src/capi_values.cpp
+++ b/src/capi_values.cpp
@@ -207,7 +207,7 @@ extern "C" {
       List, SourceSpan::tmp("sass://list"), {}, sep, is_bracketed));
   }
 
-  struct SassValue* ADDCALL sass_make_map()
+  struct SassValue* ADDCALL sass_make_map(void)
   {
     return newSassValue(SASS_MEMORY_NEW(
       Map, SourceSpan::tmp("sass://map")));


### PR DESCRIPTION
without marking this function as `(void)` C allows arbitrary arguments

after making this change, I correctly get a compile error (which I wasn't getting before):

```
_sass.c:195:12: error: too many arguments to function ‘sass_make_map’
  195 |     retv = sass_make_map(PyDict_Size(dct));
      |            ^~~~~~~~~~~~~
```